### PR TITLE
Imported the transferred repo pulumi-astra

### DIFF
--- a/src/github/repositories.ts
+++ b/src/github/repositories.ts
@@ -149,4 +149,29 @@ const terraformMigrationGuide = new github.Repository("terraform-migration-guide
     }
 );
 
-export const all = [infra, github_meta, awesome_pulumi, kubernetes_sdks, pulumi_concourse, pulumi_unifi, terraformMigrationGuide];
+const pulumi_astra = new github.Repository("pulumi-astra",
+    {
+        name: 'pulumi-astra',
+        description: 'Pulumi provider for datastax astra db',
+        hasDownloads: true,
+        hasIssues: true,
+        hasProjects: true, // false
+        hasWiki: true, // false
+        visibility: 'public',
+        vulnerabilityAlerts: true,
+        allowAutoMerge: false,
+        allowRebaseMerge: true,
+        allowSquashMerge: true, // false
+        allowMergeCommit: true,
+        deleteBranchOnMerge: false,
+        template: {
+            owner: 'pulumi',
+            repository: 'pulumi-tf-provider-boilerplate'
+        }
+    },
+    {
+        transformations: [ standardRepoTags ]
+    }
+);
+
+export const all = [infra, github_meta, awesome_pulumi, kubernetes_sdks, pulumi_concourse, pulumi_unifi, terraformMigrationGuide, pulumi_astra];


### PR DESCRIPTION
The Datastax Astra provider has been contributed to the Pulumiverse organization.
Context: https://github.com/pulumiverse/.github/issues/20

Imported the repository in the state already. Here is the code complementing this.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>