### PR TITLE
Refactor existing repository to reusable setup.

### DIFF
--- a/02-repositories/concourse.yaml
+++ b/02-repositories/concourse.yaml
@@ -1,0 +1,3 @@
+name: pulumi-concourse
+description: Pulumi provider for Concourse
+type: provider

--- a/02-repositories/unifi.yaml
+++ b/02-repositories/unifi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-unifi
+description: Pulumi provider for Unifi network gear
+type: provider

--- a/03-members/ringods.yaml
+++ b/03-members/ringods.yaml
@@ -4,3 +4,6 @@ membershipImport: owner_ringods
 teamMembershipImport: board_ringods
 maintainer:
   - governance_board
+member:
+  - pulumi-concourse
+  - pulumi-unifi

--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -20,6 +20,7 @@ export const RepositoryType = RT.Record({
     description: RT.String,
     type: RT.Union(RT.Literal('provider')),
     teams: RT.Array(RT.String).optional(),
+    import: RT.Boolean.optional(),
 })
 
 export type TeamType = Static<typeof TeamType>

--- a/src/github/repositories.ts
+++ b/src/github/repositories.ts
@@ -7,6 +7,7 @@ interface RepositoryArgs {
     description: pulumi.Input<string>,
     teams: pulumi.Input<string[]>,
     allTeams: Map<string, github.Team>;
+    import: boolean;
 }
 abstract class BaseRepository extends pulumi.ComponentResource {
 
@@ -28,7 +29,14 @@ abstract class BaseRepository extends pulumi.ComponentResource {
                 vulnerabilityAlerts: true,
             },
             {
-                parent: this
+                parent: this,
+                import: args.import ? name : undefined,
+                aliases: [
+                    {
+                        parent: pulumi.rootStackResource
+                    }
+                ],
+                transformations: [ standardRepoTags ],
             }
         );
         const mainBranchProtection = new github.BranchProtection(`${name}_protect_main`,
@@ -115,6 +123,7 @@ export function configureRepositories(repositoryArgs: RepositoryType[], allTeams
                 description: repositoryInfo.description,
                 teams: repositoryInfo.teams || [],
                 allTeams: allTeams,
+                import: repositoryInfo.import || false
             })
         }
 
@@ -201,27 +210,6 @@ const kubernetes_sdks = new github.Repository("kubernetes-sdks",
         allowSquashMerge: false,
         allowMergeCommit: false,
         deleteBranchOnMerge: true,
-    },
-    {
-        transformations: [standardRepoTags]
-    }
-);
-
-const pulumi_concourse = new github.Repository("pulumi-concourse",
-    {
-        name: 'pulumi-concourse',
-        description: 'Pulumi provider for Concourse',
-        hasDownloads: true,
-        hasIssues: true,
-        hasProjects: false,
-        hasWiki: false,
-        visibility: 'public',
-        vulnerabilityAlerts: true,
-        allowAutoMerge: false,
-        allowRebaseMerge: true,
-        allowSquashMerge: false,
-        allowMergeCommit: true,
-        deleteBranchOnMerge: false,
     },
     {
         transformations: [standardRepoTags]

--- a/src/github/repositories.ts
+++ b/src/github/repositories.ts
@@ -216,27 +216,6 @@ const kubernetes_sdks = new github.Repository("kubernetes-sdks",
     }
 );
 
-const pulumi_unifi = new github.Repository("pulumi-unifi",
-    {
-        name: 'pulumi-unifi',
-        description: 'Pulumi provider for Unifi network gear',
-        hasDownloads: false,
-        hasIssues: true,
-        hasProjects: false,
-        hasWiki: false,
-        visibility: 'public',
-        vulnerabilityAlerts: true,
-        allowAutoMerge: false,
-        allowRebaseMerge: true,
-        allowSquashMerge: false,
-        allowMergeCommit: true,
-        deleteBranchOnMerge: false,
-    },
-    {
-        transformations: [standardRepoTags]
-    }
-);
-
 const terraformMigrationGuide = new github.Repository("terraform-migration-guide",
     {
         name: 'terraform-migration-guide',


### PR DESCRIPTION
## Migrate existing repositories

In #13, we introduced a refactoring to have a more standardized setup for the provider repositories within this community. This pull request migrates two of the existing provider repositories to this setup:

* pulumi-concourse
* pulumi-unifi

## TODO

- [x] will rebase after merging #15 

Signed-off-by: Ringo De Smet <ringo@de-smet.name>