### PR TITLE
Import astra repo into standardized setup

### DIFF
--- a/02-repositories/astra.yaml
+++ b/02-repositories/astra.yaml
@@ -1,0 +1,4 @@
+name: pulumi-astra
+description: Pulumi provider for datastax astra db
+type: provider
+import: true

--- a/03-members/vavsab.yaml
+++ b/03-members/vavsab.yaml
@@ -1,0 +1,3 @@
+username: vavsab
+member:
+  - pulumi-astra

--- a/src/github/repositories.ts
+++ b/src/github/repositories.ts
@@ -235,28 +235,3 @@ const terraformMigrationGuide = new github.Repository("terraform-migration-guide
         transformations: [standardRepoTags]
     }
 );
-
-const pulumi_astra = new github.Repository("pulumi-astra",
-    {
-        name: 'pulumi-astra',
-        description: 'Pulumi provider for datastax astra db',
-        hasDownloads: true,
-        hasIssues: true,
-        hasProjects: true, // false
-        hasWiki: true, // false
-        visibility: 'public',
-        vulnerabilityAlerts: true,
-        allowAutoMerge: false,
-        allowRebaseMerge: true,
-        allowSquashMerge: true, // false
-        allowMergeCommit: true,
-        deleteBranchOnMerge: false,
-        template: {
-            owner: 'pulumi',
-            repository: 'pulumi-tf-provider-boilerplate'
-        }
-    },
-    {
-        transformations: [standardRepoTags]
-    }
-);


### PR DESCRIPTION
Migrated the maintenance of the pulumi-astra provider repository from custom Pulumi code to the standardized setup.

/cc: @vavsab you should have received an invite to join the Pulumiverse organization as a result of this migration.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>