### PR TITLE
Importing manually created repositories into automated management

### DIFF
--- a/02-repositories/configcat.yaml
+++ b/02-repositories/configcat.yaml
@@ -1,0 +1,4 @@
+name: pulumi-configcat
+description: Pulumi provider for ConfigCat
+type: provider
+import: true

--- a/02-repositories/scaleway.yaml
+++ b/02-repositories/scaleway.yaml
@@ -1,0 +1,4 @@
+name: pulumi-scaleway
+description: Pulumi provider for Scaleway, the European cloud provider
+type: provider
+import: true

--- a/03-members/jaxxstorm.yaml
+++ b/03-members/jaxxstorm.yaml
@@ -1,0 +1,3 @@
+username: jaxxstorm
+member:
+  - pulumi-scaleway

--- a/03-members/ringods.yaml
+++ b/03-members/ringods.yaml
@@ -4,4 +4,5 @@ maintainer:
   - governance_board
 member:
   - pulumi-concourse
+  - pulumi-configcat
   - pulumi-unifi

--- a/03-members/stack72.yaml
+++ b/03-members/stack72.yaml
@@ -1,2 +1,4 @@
 username: stack72
 role: admin
+member:
+  - pulumi-configcat


### PR DESCRIPTION
Importing the scaleway & configcat provider repositories under Pulumi management.

Fixes #14 

Signed-off-by: Ringo De Smet <ringo@de-smet.name>