### PR TITLE
Signing up Andreas Harter as pulumi-unifi co-maintainer

### DIFF
--- a/03-members/aharter.yaml
+++ b/03-members/aharter.yaml
@@ -1,0 +1,3 @@
+username: aharter
+maintain:
+  - pulumi-unifi


### PR DESCRIPTION
@aharter expressed interest in co-maintaining the Pulumi unifi provider:

https://twitter.com/skills404/status/1562353067378745344

After a Zoom meeting, he confirmed to take up the role as co-maintainer for `pulumi-unifi`.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>