### PR TITLE
David stepped down from Pulumiverse board

### DIFF
--- a/03-members/rawkode.yaml
+++ b/03-members/rawkode.yaml
@@ -1,5 +1,4 @@
 username: rawkode
-role: admin
 admin:
   - terraform-migration-guide
   - pulumi-doppler


### PR DESCRIPTION
David decided for himself to [step down as board member](https://github.com/pulumiverse/.github/pull/27) for the Pulumiverse board. This PR adjusts his permissions for the Pulumiverse organization accordingly.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>