### PR TITLE
Make the language versions configurable

### DIFF
--- a/.github/workflows/provider-build-sdk.yaml
+++ b/.github/workflows/provider-build-sdk.yaml
@@ -6,6 +6,18 @@ on:
       provider:
         required: true
         type: string
+      dotnetversion:
+        required: true
+        type: string
+      goversion:
+        required: true
+        type: string
+      nodeversion:
+        required: true
+        type: string
+      pythonversion:
+        required: true
+        type: string
 
 # needs: prerequisites
 
@@ -17,9 +29,13 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - ${{ inputs.dotnetversion }}
         goversion:
-        - 1.18.x
+        - ${{ inputs.goversion }}
+        nodeversion:
+        - ${{ inputs.nodeversion }}
+        pythonversion:
+        - ${{ inputs.pythonversion }}
         # javaversion:
         # - "11"
         language:
@@ -28,10 +44,6 @@ jobs:
         - dotnet
         - go
         # - java
-        nodeversion:
-        - 14.x
-        pythonversion:
-        - "3.7"
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2

--- a/.github/workflows/provider-prerequisites.yaml
+++ b/.github/workflows/provider-prerequisites.yaml
@@ -6,6 +6,18 @@ on:
       provider:
         required: true
         type: string
+      dotnetversion:
+        required: true
+        type: string
+      goversion:
+        required: true
+        type: string
+      nodeversion:
+        required: true
+        type: string
+      pythonversion:
+        required: true
+        type: string
 
 jobs:
   prerequisites:
@@ -15,13 +27,13 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 3.1.301
+        - ${{ inputs.dotnetversion }}
         goversion:
-        - 1.18.x
+        - ${{ inputs.goversion }}
         nodeversion:
-        - 14.x
+        - ${{ inputs.nodeversion }}
         pythonversion:
-        - "3.7"
+        - ${{ inputs.pythonversion }}
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2


### PR DESCRIPTION
Because of a difference in Go versions, generating the SDKs leads to slightly different generated output from the committed code:

https://github.com/pulumiverse/pulumi-matchbox/actions/runs/3457081682

To solve this, the language versions should be configurable to match the developer's environment.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>