### PR TITLE
Remove deprecated Github downloads setting.

### DIFF
--- a/src/github/repositories.ts
+++ b/src/github/repositories.ts
@@ -24,7 +24,6 @@ abstract class BaseRepository extends pulumi.ComponentResource {
                 description: args.description,
                 hasWiki: false,
                 hasIssues: true,
-                hasDownloads: args.import ? true : undefined,
                 hasProjects: false,
                 visibility: 'public',
                 deleteBranchOnMerge: true,


### PR DESCRIPTION
GitHub Downloads has been deprecated for quite a while, so remove this setting from our repo setup as well:

https://github.blog/2012-12-12-goodbye-uploads/

Signed-off-by: Ringo De Smet <ringo@de-smet.name>