### PR TITLE
Remove import key

### DIFF
--- a/02-repositories/aquasec.yaml
+++ b/02-repositories/aquasec.yaml
@@ -2,4 +2,3 @@ name: pulumi-aquasec
 description: Pulumi provider for Aquasec
 type: provider
 template: pulumi-tf-provider-boilerplate
-import: true

--- a/02-repositories/aws-eksa.yaml
+++ b/02-repositories/aws-eksa.yaml
@@ -1,4 +1,3 @@
 name: pulumi-aws-eksa
 description: Pulumi package for AWS EKS Anywhere
 type: provider
-import: true

--- a/02-repositories/doppler.yaml
+++ b/02-repositories/doppler.yaml
@@ -2,4 +2,3 @@ name: pulumi-doppler
 description: Pulumi provider for Doppler
 type: provider
 template: pulumi-tf-provider-boilerplate
-import: true

--- a/02-repositories/exoscale.yaml
+++ b/02-repositories/exoscale.yaml
@@ -2,4 +2,3 @@ name: pulumi-exoscale
 description: Pulumi provider for Exoscale
 type: provider
 template: pulumi-tf-provider-boilerplate
-import: true

--- a/02-repositories/heroku.yaml
+++ b/02-repositories/heroku.yaml
@@ -2,4 +2,3 @@ name: pulumi-heroku
 description: Pulumi provider for Heroku
 type: provider
 template: pulumi-tf-provider-boilerplate
-import: true

--- a/02-repositories/time.yaml
+++ b/02-repositories/time.yaml
@@ -2,4 +2,3 @@ name: pulumi-time
 description: Pulumi Time provider used to interact with time-based resources.
 type: provider
 template: pulumi-tf-provider-boilerplate
-import: true

--- a/02-repositories/vra.yaml
+++ b/02-repositories/vra.yaml
@@ -2,4 +2,3 @@ name: pulumi-vra
 description: Learn how to make a Pulumi provider and make one for VRA.
 type: provider
 template: pulumi-tf-provider-boilerplate
-import: true


### PR DESCRIPTION
The repositories have been imported and are under Pulumi management. The `import` key can be removed now.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>