### PR TITLE
Pass Github token to fetch schema-tools release

### DIFF
--- a/.github/workflows/provider-prerequisites.yaml
+++ b/.github/workflows/provider-prerequisites.yaml
@@ -61,6 +61,8 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
         repo: mikhailshilkov/schema-tools
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
     - name: Build tfgen & provider binaries
       run: make provider
     - if: github.event_name == 'pull_request'


### PR DESCRIPTION
Because `schema-tools` is in another repository, the Github token needs to be passed to fetch it correctly.

Change needed to get the HCP provider release working: https://github.com/pulumiverse/pulumi-hcp/pull/33
Current failing build: https://github.com/pulumiverse/pulumi-hcp/actions/runs/5175283385/jobs/9322680667