### PR TITLE
Specifying GitHub Template for FortiOS provider

### DIFF
--- a/02-repositories/fortios.yaml
+++ b/02-repositories/fortios.yaml
@@ -1,3 +1,4 @@
 name: pulumi-fortios
 description: Pulumi provider for managing Fortinet FortiOS
 type: provider
+template: pulumi-tf-provider-boilerplate


### PR DESCRIPTION
Looks like the code repo wasn't created, maybe due to missing template specification? Correcting that.