### PR TITLE
Upgrade GitHub actions to latest versions to fix Node 12 deprecated w…

### DIFF
--- a/.github/workflows/provider-build-sdk.yaml
+++ b/.github/workflows/provider-build-sdk.yaml
@@ -56,16 +56,16 @@ jobs:
     - name: Install Pulumi CLI
       uses: pulumi/actions@v4
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.nodeversion }}
         registry-url: https://registry.npmjs.org
     - name: Setup DotNet
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ inputs.dotnetversion }}
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.pythonversion }}
     # - name: Setup Java
@@ -75,7 +75,7 @@ jobs:
     #     distribution: temurin
     #     java-version: ${{ inputs.javaversion }}
     - name: Download provider + tfgen binaries
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ${{ inputs.provider }}-provider.tar.gz
         path: ${{ github.workspace }}/bin
@@ -99,7 +99,7 @@ jobs:
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz

--- a/.github/workflows/provider-prerequisites.yaml
+++ b/.github/workflows/provider-prerequisites.yaml
@@ -72,7 +72,7 @@ jobs:
         github.workspace }}/bin/ pulumi-resource-${{ inputs.provider }}
         pulumi-tfgen-${{ inputs.provider }}
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.provider }}-provider.tar.gz
         path: ${{ github.workspace }}/bin/provider.tar.gz


### PR DESCRIPTION
Upgraded GitHub action versions to fix the following warning:

```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-node@v2, actions/setup-dotnet@v1, actions/setup-python@v2, actions/download-artifact@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```