### PR TITLE
Auto assign issues & PRs to the board

### DIFF
--- a/.github/workflows/auto-issue-assignment.yaml
+++ b/.github/workflows/auto-issue-assignment.yaml
@@ -1,0 +1,18 @@
+name: Issue assignment
+
+on:
+    issues:
+        types: [opened]
+
+jobs:
+    auto-assign:
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+        steps:
+            - name: 'Auto-assign issue'
+              uses: pozil/auto-assign-issue@v1
+              with:
+                  assignees: ringods, simenandre, dirien, usrbinkat, rebelopsio
+                  numOfAssignee: 5
+                  allowSelfAssign: false

--- a/.github/workflows/auto-issue-assignment.yaml
+++ b/.github/workflows/auto-issue-assignment.yaml
@@ -13,6 +13,7 @@ jobs:
             - name: 'Auto-assign issue'
               uses: pozil/auto-assign-issue@v1
               with:
-                  assignees: ringods, simenandre, dirien, usrbinkat, rebelopsio
-                  numOfAssignee: 5
-                  allowSelfAssign: false
+                repo-token: ${{ secrets.GITHUB_TOKEN }}
+                assignees: ringods, simenandre, dirien, usrbinkat, rebelopsio
+                numOfAssignee: 5
+                allowSelfAssign: false

--- a/.github/workflows/auto-pr-assignment.yaml
+++ b/.github/workflows/auto-pr-assignment.yaml
@@ -1,0 +1,18 @@
+name: PR assignment
+
+on:
+    pull_request:
+        types: [opened]
+
+jobs:
+    auto-assign:
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+        steps:
+            - name: 'Auto-assign issue'
+              uses: pozil/auto-assign-issue@v1
+              with:
+                  assignees: ringods, simenandre, dirien, usrbinkat, rebelopsio
+                  numOfAssignee: 5
+                  allowSelfAssign: false

--- a/.github/workflows/auto-pr-assignment.yaml
+++ b/.github/workflows/auto-pr-assignment.yaml
@@ -13,6 +13,7 @@ jobs:
             - name: 'Auto-assign issue'
               uses: pozil/auto-assign-issue@v1
               with:
-                  assignees: ringods, simenandre, dirien, usrbinkat, rebelopsio
-                  numOfAssignee: 5
-                  allowSelfAssign: false
+                repo-token: ${{ secrets.GITHUB_TOKEN }}
+                assignees: ringods, simenandre, dirien, usrbinkat, rebelopsio
+                numOfAssignee: 5
+                allowSelfAssign: false


### PR DESCRIPTION
Automatically assign issues and pull requests to the board members. 
If the issue or the PR is created by one of the board members, the issue or PR will not be self-assigned.