### PR TITLE
Use Pulumi `protect` to prevent accidental repo deletion

### DIFF
--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -33,6 +33,7 @@ export const Repository = RT.Record({
     labels: RT.Array(Labels).optional(),
     import: RT.Boolean.optional(),
     template: RT.String.optional(),
+    removable: RT.Boolean.optional(),
 })
 
 export type Team = Static<typeof Team>

--- a/src/github/repositories.ts
+++ b/src/github/repositories.ts
@@ -17,6 +17,7 @@ interface RepositoryArgs {
     allTeams: Map<string, github.Team>;
     import: boolean;
     template: pulumi.Input<string> | undefined;
+    removable: boolean;
 }
 abstract class BaseRepository extends pulumi.ComponentResource {
 
@@ -50,6 +51,7 @@ abstract class BaseRepository extends pulumi.ComponentResource {
                     }
                 ],
                 transformations: this.repositoryTransformations(),
+                protect: !args.removable
             }
         );
         const mainBranchProtection = new github.BranchProtection(`${name}_protect_main`,
@@ -190,6 +192,7 @@ export function configureRepositories(repositoryArgs: Repository[], allTeams: Ma
                     allTeams: allTeams,
                     import: repositoryInfo.import || false,
                     template: repositoryInfo.template,
+                    removable: repositoryInfo.removable || false,
                 }).repository);
                 break;
             }
@@ -202,6 +205,7 @@ export function configureRepositories(repositoryArgs: Repository[], allTeams: Ma
                     allTeams: allTeams,
                     import: repositoryInfo.import || false,
                     template: repositoryInfo.template,
+                    removable: repositoryInfo.removable || false,
                 }).repository);
                 break;
             }
@@ -215,6 +219,7 @@ export function configureRepositories(repositoryArgs: Repository[], allTeams: Ma
                         allTeams,
                         import: repositoryInfo.import || false,
                         template: repositoryInfo.template,
+                        removable: repositoryInfo.removable || false,
                     }).repository
                 );
                 break;


### PR DESCRIPTION
Adding Pulumi `protect` resource option to prevent accidental deletion of Github repositories.

Context: https://github.com/pulumiverse/infra/pull/128#issuecomment-1809688565