### PR TITLE
refactor: assign tmeckel admin role, pulumi-time as maintainer

### DIFF
--- a/03-members/tmeckel.yaml
+++ b/03-members/tmeckel.yaml
@@ -1,6 +1,6 @@
 username: tmeckel
-push:
-  - pulumi-time
+role: admin
 maintain:
+  - pulumi-time
   - pulumi-mssql
   - pulumi-fortios


### PR DESCRIPTION
# Changes

* `refactor`: assign tmeckel admin role as Pulumiverse board member 
* `refactor`: assign maintainer role for `pulumi-time` provider
