### PR TITLE
Import the migrated Dynatrace provider into the managed GH organization

### DIFF
--- a/02-repositories/dynatrace.yaml
+++ b/02-repositories/dynatrace.yaml
@@ -1,0 +1,6 @@
+name: pulumi-dynatrace
+description: Pulumi provider for Dynatrace
+type: provider
+template: pulumi-tf-provider-boilerplate
+import: true
+hasDownloads: true

--- a/03-members/pierskarsenbarg.yaml
+++ b/03-members/pierskarsenbarg.yaml
@@ -1,3 +1,4 @@
 username: pierskarsenbarg
 maintain:
+  - pulumi-dynatrace
   - pulumi-ngrok


### PR DESCRIPTION
The Dynatrace provider repository is migrated from the `lbrlabs` organization. @pierskarsenbarg will manage this one going forward.

The `import` property has been set to `true` to make sure the existing repository is imported into the Pulumi state vs trying to recreate it as a new repository.

Plz make sure this provider gets integrated in the Pulumi managed infrastructure setup.