### PR TITLE
refactor: setting repo access for tmeckel to admin

### DIFF
--- a/03-members/tmeckel.yaml
+++ b/03-members/tmeckel.yaml
@@ -1,6 +1,6 @@
 username: tmeckel
 role: admin
-maintain:
+admin:
   - pulumi-time
   - pulumi-mssql
   - pulumi-fortios


### PR DESCRIPTION
Setting repository access for `tmeckel` to `admin` in all relevant repositories to prevent diffs in Pulumi because the admin role gets enforced via the admin role in the Pulumiverse organization