### PR TITLE
Remove `ringods` from issue and PR auto assignment

### DIFF
--- a/.github/workflows/auto-issue-assignment.yaml
+++ b/.github/workflows/auto-issue-assignment.yaml
@@ -14,6 +14,6 @@ jobs:
               uses: pozil/auto-assign-issue@v1
               with:
                 repo-token: ${{ secrets.GITHUB_TOKEN }}
-                assignees: ringods, simenandre, rebelopsio, tmeckel
+                assignees: simenandre, rebelopsio, tmeckel
                 numOfAssignee: 5
                 allowSelfAssign: false

--- a/.github/workflows/auto-pr-assignment.yaml
+++ b/.github/workflows/auto-pr-assignment.yaml
@@ -14,6 +14,6 @@ jobs:
               uses: pozil/auto-assign-issue@v1
               with:
                 repo-token: ${{ secrets.GITHUB_TOKEN }}
-                assignees: ringods, simenandre, rebelopsio, tmeckel
+                assignees: simenandre, rebelopsio, tmeckel
                 numOfAssignee: 5
                 allowSelfAssign: false


### PR DESCRIPTION
Since I'm no longer on the board, I'm removing myself from the auto assignment of issues and PRs in this repo.