### PR TITLE
Allow Pulumi previews from forked repositories

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,6 @@
 name: Pull Request
 on:
-  pull_request:
+  pull_request_target:
     paths-ignore:
       - '.github/workflows/provider-*.yaml'
 


### PR DESCRIPTION
Updating the `pull-request.yml` workflow from `pull_request` to `pull_request_target` event to allow Pulumi previews to run succesfully when the change is provided via a forked repository.
