### PR TITLE
fix: issues after upgrade to GitHub v6

### DIFF
--- a/src/github/repositories.ts
+++ b/src/github/repositories.ts
@@ -70,7 +70,8 @@ abstract class BaseRepository extends pulumi.ComponentResource {
                 }],
             },
             {
-                parent: this
+                parent: this,
+                deleteBeforeReplace: true,
             }
         );
 


### PR DESCRIPTION
* fix: add deleteBeforeReplace on github.BranchProtection to cope with issue after upgrade to v6 of the GitHub provider