### PR TITLE
Required labels for pulumi/upgrade-provider to work correctly

### DIFF
--- a/02-repositories/acme.yaml
+++ b/02-repositories/acme.yaml
@@ -2,3 +2,19 @@ name: pulumi-acme
 description: Pulumi provider for ACME
 type: provider
 template: pulumi-tf-provider-boilerplate
+labels:
+  - name: needs-release/major
+    color: c4dff5
+    description: Indicates that this PR requires a major release after merging
+  - name: needs-release/minor
+    color: c4dff5
+    description: Indicates that this PR requires a minor release after merging
+  - name: needs-release/patch
+    color: c4dff5
+    description: Indicates that this PR requires a minor release after merging
+  - name: kind/bug
+    color: bfd4f2
+    description: Some behavior is incorrect or out of spec
+  - name: kind/enhancement
+    color: bfd4f2
+    description: Improvements or new features

--- a/02-repositories/matchbox.yaml
+++ b/02-repositories/matchbox.yaml
@@ -2,3 +2,19 @@ name: pulumi-matchbox
 description: Pulumi provider for the Matchbox iPXE server
 type: provider
 template: pulumi-tf-provider-boilerplate
+labels:
+  - name: needs-release/major
+    color: c4dff5
+    description: Indicates that this PR requires a major release after merging
+  - name: needs-release/minor
+    color: c4dff5
+    description: Indicates that this PR requires a minor release after merging
+  - name: needs-release/patch
+    color: c4dff5
+    description: Indicates that this PR requires a minor release after merging
+  - name: kind/bug
+    color: bfd4f2
+    description: Some behavior is incorrect or out of spec
+  - name: kind/enhancement
+    color: bfd4f2
+    description: Improvements or new features


### PR DESCRIPTION
I'm testing the automatic generation of workflows by [pulumi/ci-mgmt](https://github.com/pulumi/ci-mgmt/) in two of my providers: `acme` and `matchbox`.

The workflows related to upgrading the Pulumi provider with new versions of the Terraform bridge or the upstream TF provider use the [pulumi/upgrade-provider](https://github.com/pulumi/upgrade-provider/) tool. This tool requires some issue/PR labels to exist. Label definitions match [the ones used by Pulumi Corp](https://github.com/pulumi/team-management/blob/main/infra/labels.go) as close as possible.

Without these labels, some workflows will error, for instance like this:
https://github.com/pulumiverse/pulumi-matchbox/actions/runs/11237730217/job/31240815044

I added these required labels in the setup of these 2 test providers. 

**NOTE:** It's possible Pulumi will complain some of these labels already exist. Please either import the labels into the Pulumi state, or remove these labels from the repo and re-apply this PR.