### PR TITLE
Add wildcards to paths

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,12 +3,11 @@ on:
   pull_request:
     paths-ignore:
       - '.github/workflows/provider-*.yaml'
-
   pull_request_target:
     paths:
-      - '01-teams'
-      - '02-repositories'
-      - '03-members'
+      - '01-teams/**'
+      - '02-repositories/**'
+      - '03-members/**'
 
 jobs:
   preview-changes:


### PR DESCRIPTION
The `pull-request` workflow should handle 2 cases:

* `pull_request` event: a PR created directly in the `infra` repository by an authorized user
* `pull_request_target` event: a PR created in a fork of the `infra` repository by an external contributor when the changes only map to the YAML config files

My previous PR, #228, only changed such config files, but still the `pull_request` event was triggered:

https://github.com/pulumiverse/infra/actions/runs/11250271518

<img width="892" alt="Screenshot 2024-10-11 at 15 51 40" src="https://github.com/user-attachments/assets/6d054599-a1ae-4150-beb1-30a2565c70ed">

I'm guessing that the `pull_request_target` event wasn't sent because it didn't match the folder names. Hence, the proposed change is to add wildcards after each.