### PR TITLE
Archive the concourse provider

### DIFF
--- a/02-repositories/concourse.yaml
+++ b/02-repositories/concourse.yaml
@@ -1,3 +1,4 @@
 name: pulumi-concourse
 description: Pulumi provider for Concourse
 type: provider
+archived: true

--- a/03-members/ringods.yaml
+++ b/03-members/ringods.yaml
@@ -2,7 +2,6 @@ username: ringods
 admin:
   - pulumi-acme
   - pulumi-cockroach
-  - pulumi-concourse
   - pulumi-configcat
   - pulumi-doppler
   - pulumi-gandi


### PR DESCRIPTION
Concourse CI isn't really a highly used CI system, let alone that people were managing it using Pulumi. Archiving this provider as a result.