### PR TITLE
cicd: Change sequence of pull_request_target and pull_request triggers in Pull Request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,13 +1,13 @@
 name: Pull Request
 on:
-  pull_request:
-    paths-ignore:
-      - '.github/workflows/provider-*.yaml'
   pull_request_target:
     paths:
       - '01-teams/**'
       - '02-repositories/**'
       - '03-members/**'
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/provider-*.yaml'
 
 jobs:
   preview-changes:


### PR DESCRIPTION
To ensure that `pull_request_target` is called when configuration files changed which are allowed to be modified via a forked pull request, `pull_request_target` is now defined **before** the `pull_request` trigger.