### PR TITLE
Adding issue labels to unifi & scaleway providers

### DIFF
--- a/02-repositories/scaleway.yaml
+++ b/02-repositories/scaleway.yaml
@@ -2,4 +2,19 @@ name: pulumi-scaleway
 description: Pulumi provider for Scaleway
 type: provider
 template: pulumi-tf-provider-boilerplate
-import: true
+labels:
+  - name: needs-release/major
+    color: c4dff5
+    description: Indicates that this PR requires a major release after merging
+  - name: needs-release/minor
+    color: c4dff5
+    description: Indicates that this PR requires a minor release after merging
+  - name: needs-release/patch
+    color: c4dff5
+    description: Indicates that this PR requires a minor release after merging
+  - name: kind/bug
+    color: bfd4f2
+    description: Some behavior is incorrect or out of spec
+  - name: kind/enhancement
+    color: bfd4f2
+    description: Improvements or new features

--- a/02-repositories/unifi.yaml
+++ b/02-repositories/unifi.yaml
@@ -1,3 +1,19 @@
 name: pulumi-unifi
 description: Pulumi provider for Unifi network gear
 type: provider
+labels:
+  - name: needs-release/major
+    color: c4dff5
+    description: Indicates that this PR requires a major release after merging
+  - name: needs-release/minor
+    color: c4dff5
+    description: Indicates that this PR requires a minor release after merging
+  - name: needs-release/patch
+    color: c4dff5
+    description: Indicates that this PR requires a minor release after merging
+  - name: kind/bug
+    color: bfd4f2
+    description: Some behavior is incorrect or out of spec
+  - name: kind/enhancement
+    color: bfd4f2
+    description: Improvements or new features


### PR DESCRIPTION
Adding issue labels to unifi & scaleway providers which are required by the workflows generated from https://github.com/pulumi/ci-mgmt