### PR TITLE
Add `ringods` as maintainer of the `zitadel` provider

### DIFF
--- a/03-members/ringods.yaml
+++ b/03-members/ringods.yaml
@@ -10,3 +10,4 @@ admin:
   - pulumi-sentry
   - pulumi-talos
   - pulumi-unifi
+  - pulumi-zitadel


### PR DESCRIPTION
Add myself as maintainer of the `zitadel` provider.
This is due to personal interest running an IdP within my homelab.