### PR TITLE
Upgrade permissions to the Zitadel people

### DIFF
--- a/03-members/adlerhurst.yaml
+++ b/03-members/adlerhurst.yaml
@@ -1,3 +1,3 @@
 username: adlerhurst
-push:
+maintain:
   - pulumi-zitadel

--- a/03-members/eliobischof.yaml
+++ b/03-members/eliobischof.yaml
@@ -1,3 +1,3 @@
 username: eliobischof
-push:
+admin:
   - pulumi-zitadel

--- a/03-members/livio-a.yaml
+++ b/03-members/livio-a.yaml
@@ -1,3 +1,3 @@
 username: livio-a
-push:
+maintain:
   - pulumi-zitadel

--- a/03-members/stebenz.yaml
+++ b/03-members/stebenz.yaml
@@ -1,3 +1,3 @@
 username: stebenz
-push:
+maintain:
   - pulumi-zitadel


### PR DESCRIPTION
Upgrade permissions to the Zitadel people to maintain their own provider.

They only had `push` permissions, but are now `admin` and `maintain`er on the repo.

CC:
- @eliobischof 
- @adlerhurst 
- @livio-a
- @stebenz