### PR TITLE
Make marns93 admin for pulumi-heroku provider

### DIFF
--- a/03-members/marns93.yaml
+++ b/03-members/marns93.yaml
@@ -1,3 +1,3 @@
 username: marns93
-push:
+admin:
   - pulumi-heroku


### PR DESCRIPTION
I'm the only maintainer for `pulumi-heroku` and I can't merge my PR's without an approval from somebody with write access. Either we need to find another maintainer for this repository, or update the permissions.

Related PR: https://github.com/pulumiverse/pulumi-heroku/pull/123