### PR TITLE
Add ClickHouse database operations Pulumi provider

### DIFF
--- a/02-repositories/clickhousedbops.yaml
+++ b/02-repositories/clickhousedbops.yaml
@@ -1,0 +1,5 @@
+name: pulumi-clickhousedbops
+description: Pulumi provider for ClickHouse database operations (users, roles, grants)
+type: provider
+template: pulumi-tf-provider-boilerplate
+workflows: ci-mgmt


### PR DESCRIPTION
## Summary
This PR adds a new Pulumi provider configuration for ClickHouse database operations, enabling infrastructure-as-code management of ClickHouse users, roles, and grants.

## Key Changes
- Added `pulumi-clickhousedbops` provider repository configuration
- Configured as a Terraform-based provider using the standard boilerplate template
- Integrated with CI management workflows for automated testing and deployment

## Implementation Details
- **Provider Name**: pulumi-clickhousedbops
- **Type**: Terraform provider wrapper
- **Capabilities**: Manages ClickHouse database operations including users, roles, and grants
- **Template**: Uses `pulumi-tf-provider-boilerplate` for consistent provider structure
- **CI/CD**: Configured with `ci-mgmt` workflows for continuous integration

https://claude.ai/code/session_01FmTwyopU5CMiR1mZnKfVLw