### PR TITLE
feat: add pulumi-unleash provider and hagaym1 as maintainer

### DIFF
--- a/02-repositories/unleash.yaml
+++ b/02-repositories/unleash.yaml
@@ -1,5 +1,4 @@
 name: pulumi-unleash
 description: Pulumi provider for Unleash
 type: provider
-template: pulumi-tf-provider-boilerplate
 workflows: ci-mgmt

--- a/02-repositories/unleash.yaml
+++ b/02-repositories/unleash.yaml
@@ -1,0 +1,5 @@
+name: pulumi-unleash
+description: Pulumi provider for Unleash
+type: provider
+template: pulumi-tf-provider-boilerplate
+workflows: ci-mgmt

--- a/03-members/hagaym1.yaml
+++ b/03-members/hagaym1.yaml
@@ -1,0 +1,3 @@
+username: hagaym1
+admin:
+  - pulumi-unleash


### PR DESCRIPTION
Follows up https://github.com/pulumiverse/.github/issues/45, per @tmeckel's pointer to #353.

Adds the repository entry and myself as its maintainer. `template` and `workflows` match the other
TF-bridged providers (configcat, grafana, vercel) — it's built from
`pulumi-tf-provider-boilerplate` with ci-mgmt-generated workflows.

## One question on mechanics

The provider already exists and works at https://github.com/hagaym1/pulumi-unleash — 12 commits,
13 resources and 8 data sources bridged, all four SDKs building, an end-to-end test that creates and
destroys a real `ApiToken` against an OSS Unleash container. Nothing published, no tags cut.

So there are two ways to land it, and I don't know which you prefer:

1. I transfer the existing repo into the org, preserving history — in which case this entry may
   need `import: true`, as `grafana.yaml` has.
2. You create an empty `pulumiverse/pulumi-unleash` and I push into it.

Happy either way — tell me which and I'll do the module-path and package-name rewrite
(`hagaym1` → `pulumiverse`) as part of the move. Package naming is deliberately still provisional so
there's one identity rather than an orphaned first release.

## On maintenance

Yes, I'm signing up to maintain it.

Worth flagging one ceiling honestly rather than having it discovered later: Unleash's community
build registers no write routes for `/api/admin/projects` or `/api/admin/environments`, so
project/environment creation is Enterprise-only in practice, and an Enterprise licence secret isn't
available to fork PRs regardless of who owns the repo. Live CI therefore exercises `ApiToken` only;
everything else gets compile and schema-generation coverage. That ceiling is a property of Unleash
OSS, not of this provider.
